### PR TITLE
Fix XML parsing error in firefox on post delete

### DIFF
--- a/server/routes/api/posts.js
+++ b/server/routes/api/posts.js
@@ -23,7 +23,7 @@ router.post('/', async (req, res) => {
 router.delete('/:id', async (req, res) => {
   const posts = await loadPostsCollection();
   await posts.deleteOne({ _id: new mongodb.ObjectID(req.params.id) });
-  res.status(200).send();
+  res.status(200).send({});
 });
 
 async function loadPostsCollection() {


### PR DESCRIPTION
Unless an empty object is passed in the delete response, Firefox will not update the page and will log the following error to the console:

XML Parsing Error: no root element found Location: http://localhost:5000/api/posts/5c0511d63477542ca9e3febc Line Number 1, Column 1: